### PR TITLE
Fix display search municipality and community

### DIFF
--- a/components/MainPage/SearchBox.js
+++ b/components/MainPage/SearchBox.js
@@ -401,15 +401,21 @@ class SearchBox extends React.Component {
       )
       .map(place => {
         let name = this.getTopographicalNames(place);
-        return {
-          text: name,
-          id: place.id,
-          value: (
-            <MenuItem
-              primaryText={name}
-              style={{fontSize: '0.8em'}}
-              secondaryText={formatMessage({ id: place.topographicPlaceType })}
-            />
+        let shortName = this.getTopographicalNames(place);
+
+          if(shortName.length > 35){
+              shortName = shortName.substring(0, 35) + "...";
+          }
+
+          return {
+              text: name,
+              id: place.id,
+              value: (
+                  <MenuItem
+                      primaryText={shortName}
+                      style={{fontSize: '0.8em'}}
+                      secondaryText={formatMessage({ id: place.topographicPlaceType })}
+                  />
           ),
           type: place.topographicPlaceType
         };
@@ -500,17 +506,19 @@ class SearchBox extends React.Component {
                         floatingLabelText={formatMessage({
                           id: 'filter_by_topography'
                         })}
-                        hintText={formatMessage({ id: 'filter_by_topography' })}
+                        floatingLabelStyle={{marginTop: -22, marginLeft: 5}}
                         dataSource={topographicalPlacesDataSource}
                         onUpdateInput={this.handleTopographicalPlaceInput.bind(
-                          this
+                            this
                         )}
                         filter={AutoComplete.caseInsensitiveFilter}
                         style={{
-                          margin: 'auto',
-                          width: '100%',
-                          marginTop: -20,
+                            margin: 'auto',
+                            width: '100%',
+                            marginTop: -20
                         }}
+                        menuStyle={{width: 450}}
+                        listStyle={{width: 450}}
                         maxSearchResults={7}
                         ref="topoFilter"
                         onNewRequest={this.handleAddChip.bind(this)}

--- a/components/MainPage/TopographicalFilter.js
+++ b/components/MainPage/TopographicalFilter.js
@@ -12,7 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the Licence for the specific language governing permissions and
 limitations under the Licence. */
 
-import React from 'react';
+
+import React from 'react';
 import Chip from 'material-ui/Chip';
 
 class TopographicalFilter extends React.Component {
@@ -25,18 +26,19 @@ class TopographicalFilter extends React.Component {
     const chipStyle = {
       margin: 4,
       backgroundColor: typeColor,
+      maxWidth: 440
     };
 
-    let id = data.id || data.value;
+      let id = data.id || data.value;
 
-    return (
-      <Chip
-        key={id}
-        onRequestDelete={() => this.props.handleDeleteChip(id)}
-        style={chipStyle}
-      >
-        <span style={{ color: typeTextColor, fontSize: '0.8em' }}>{data.text}</span>
-      </Chip>
+      return (
+          <Chip
+              key={id}
+              onRequestDelete={() => this.props.handleDeleteChip(id)}
+              style={chipStyle}
+          >
+              <span style={{ color: typeTextColor, fontSize: '0.8em', whiteSpace:'normal', lineHeight: data.text.length > 80 ? '22px' : '32px'}}>{data.text}</span>
+          </Chip>
     );
   }
 


### PR DESCRIPTION
Long names in topo places search box get squashed :
![selection_044](https://user-images.githubusercontent.com/1476276/35676731-3b1e3c0e-074d-11e8-8c70-654cf2895ccb.png)

Now there's an ellipse if too long, and some text has been moved for better spacing :

![selection_046](https://user-images.githubusercontent.com/1476276/35676982-2f51cb10-074e-11e8-8692-6a6d968e002a.png)

