### PR TITLE
WTK-136 fix for versioning of previous child stops

### DIFF
--- a/src/components/EditStopPage/VersionsPopover.js
+++ b/src/components/EditStopPage/VersionsPopover.js
@@ -17,6 +17,7 @@ import PropTypes from "prop-types";
 import Popover, { PopoverAnimationVertical } from "material-ui/Popover";
 import Menu from "material-ui/Menu";
 import MenuItem from "material-ui/MenuItem";
+import { sortVersions } from "../../utils";
 
 class VersionsPopover extends Component {
   constructor(props) {
@@ -76,7 +77,7 @@ class VersionsPopover extends Component {
           animation={PopoverAnimationVertical}
         >
           <Menu menuItemStyle={{ fontSize: 12 }} autoWidth={true}>
-            {versions.map((version, i) => (
+            {sortVersions(versions).map((version, i) => (
               <MenuItem
                 key={"version" + i}
                 primaryText={

--- a/src/utils/__tests__/index.js
+++ b/src/utils/__tests__/index.js
@@ -16,4 +16,30 @@ describe("getIsCurrentVersionMax", () => {
   test("Current version is max", () => {
     expect(getIsCurrentVersionMax([{ version: 2 }], "2", false)).toBeTruthy();
   });
+
+  test("Empty toDate has precedence over version number", () => {
+    expect(
+      getIsCurrentVersionMax(
+        [
+          { version: 2, toDate: "2010-12-10 19:30" },
+          { version: 1, toDate: "" },
+        ],
+        "1",
+        false
+      )
+    ).toBeTruthy();
+  });
+
+  test("Compare toDates", () => {
+    expect(
+      getIsCurrentVersionMax(
+        [
+          { version: 1, toDate: "2010-12-10 19:30" },
+          { version: 2, toDate: "2010-12-11 19:30" },
+        ],
+        "2",
+        false
+      )
+    ).toBeTruthy();
+  });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -85,6 +85,13 @@ export const toCamelCase = (string) => {
   });
 };
 
+export const sortVersions = (versions) =>
+  versions.sort((a, b) => {
+    if (a.toDate === "") return -1;
+    if (b.toDate === "") return 1;
+    else return new Date(b.toDate) - new Date(a.toDate);
+  });
+
 export const getIsCurrentVersionMax = (
   versions,
   currentVersion,
@@ -101,9 +108,12 @@ export const getIsCurrentVersionMax = (
   // also when creating a new stop place
   if (!currentVersion) return true;
 
-  const versionsOfStop = versions.map((version) => version.version);
-  const maxVersion = Math.max(...versionsOfStop);
-  return maxVersion === Number(currentVersion);
+  // Check if the current version is the newest version, according to version sorted by toDate
+  return (
+    sortVersions(versions).findIndex(
+      ({ version }) => version === Number(currentVersion)
+    ) === 0
+  );
 };
 
 export const findDuplicateImportedIds = (stopPlaces) => {


### PR DESCRIPTION
Make sorting function based on toDate. Make sure that empty toDate is
sorted at the top. Compare currentVersion with indices of the sorted
versions to determine if it is the latest version. Use the same sorting
for display of versions in popup.