### PR TITLE
fix: missing permissions for gosp

### DIFF
--- a/src/actions/StopPlacesGroupActions.js
+++ b/src/actions/StopPlacesGroupActions.js
@@ -26,17 +26,11 @@ var StopPlacesGroupActions = {};
 StopPlacesGroupActions.useStopPlaceIdForNewGroup =
   (stopPlaceId) => (dispatch) => {
     dispatch(createThunk(types.CREATED_NEW_GROUP_OF_STOP_PLACES, stopPlaceId));
-    // i.e already creating a new group of stop place, update state instead
-    if (
-      window.location.pathname.indexOf(`/${Routes.GROUP_OF_STOP_PLACE}/new`) >
-      -1
-    ) {
-      dispatch(StopPlacesGroupActions.createNewGroup(stopPlaceId));
-    } else {
+    dispatch(StopPlacesGroupActions.createNewGroup(stopPlaceId)).then(() => {
       dispatch(
         UserActions.navigateTo(`/${Routes.GROUP_OF_STOP_PLACE}/`, "new"),
       );
-    }
+    });
   };
 
 StopPlacesGroupActions.changeName = (name) => (dispatch) => {
@@ -71,8 +65,8 @@ StopPlacesGroupActions.discardChanges = () => (dispatch) => {
   dispatch(createThunk(types.DISCARDED_GOS_CHANGES, null));
 };
 
-StopPlacesGroupActions.createNewGroup = (stopPlaceId) => (dispatch) => {
-  dispatch(getStopPlaceById(stopPlaceId))
+StopPlacesGroupActions.createNewGroup = (stopPlaceId) => async (dispatch) => {
+  return dispatch(getStopPlaceById(stopPlaceId))
     .then((result) => {
       if (
         result &&

--- a/src/components/GroupOfStopPlaces/EditGroupOfStopPlaces.js
+++ b/src/components/GroupOfStopPlaces/EditGroupOfStopPlaces.js
@@ -27,7 +27,6 @@ import {
 import * as types from "../../actions/Types";
 import mapHelper from "../../modelUtils/mapToQueryVariables";
 import Routes from "../../routes/";
-import { getStopPermissions } from "../../utils/permissionsUtils";
 import ConfirmDialog from "../Dialogs/ConfirmDialog";
 import SaveGroupDialog from "../Dialogs/SaveGroupDialog";
 import GroupOfStopPlaceDetails from "./GroupOfStopPlacesDetails";
@@ -168,7 +167,7 @@ class EditGroupOfStopPlaces extends Component {
                 margin: "8 5",
                 zIndex: 999,
                 fontSize: "0.7em",
-                color: "#000",
+                color: !canDelete ? "#999" : "#000",
               }}
               disabled={!canDelete}
               onClick={() => {
@@ -288,8 +287,8 @@ const mapStateToProps = ({ stopPlacesGroup }) => ({
   isModified: stopPlacesGroup.isModified,
   groupOfStopPlaces: stopPlacesGroup.current,
   originalGOS: stopPlacesGroup.original,
-  canEdit: getStopPermissions(stopPlacesGroup.current).canEdit,
-  canDelete: getStopPermissions(stopPlacesGroup.current).canDelete,
+  canEdit: stopPlacesGroup.current.permissions?.canEdit,
+  canDelete: stopPlacesGroup.current.permissions?.canDelete,
 });
 
 export default connect(mapStateToProps)(injectIntl(EditGroupOfStopPlaces));

--- a/src/graphql/Tiamat/queries.js
+++ b/src/graphql/Tiamat/queries.js
@@ -663,6 +663,9 @@ export const getStopPlacesById = (stopPlaceIds) => {
                 name {
                     value
                 }
+                permissions {
+                  ...EntityPermissions
+                }
                 submode
                 geometry {
                   legacyCoordinates
@@ -687,6 +690,9 @@ export const getStopPlacesById = (stopPlaceIds) => {
                 name {
                     value
                 }
+                permissions {
+                  ...EntityPermissions
+                }
                 geometry {
                   legacyCoordinates
                 }
@@ -708,6 +714,7 @@ export const getStopPlacesById = (stopPlaceIds) => {
       query getAddStopPlaceInfo {
           ${queryContent}
       }
+      ${Fragments.entityPermissions}
   `;
 };
 

--- a/src/reducers/groupReducerUtils.js
+++ b/src/reducers/groupReducerUtils.js
@@ -51,6 +51,11 @@ export const addMemberToGroup = (current, payload) => {
 
   newGroup.members = newGroup.members.concat(members);
 
+  newGroup.permissions = {
+    canEdit: true,
+    canDelete: true,
+  };
+
   return newGroup;
 };
 


### PR DESCRIPTION
When creating new GOSP, the new entity was missing permissions. This PR also fixes related issues, including editing permissions.

Thanks to @esuomi for reporting.