### PR TITLE
Use redirect uri specified in oidc config

### DIFF
--- a/src/auth/auth.tsx
+++ b/src/auth/auth.tsx
@@ -88,7 +88,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           window.location.pathname,
         );
       }}
-      redirect_uri={window.location.origin}
+      redirect_uri={
+        oidcConfig?.redirect_uri ||
+        window.location.origin + import.meta.env.BASE_URL
+      }
     >
       {children}
     </OidcAuthProvider>


### PR DESCRIPTION
Before `window.location.origin` was used, but it can be beneficial to also be able to supply a value from bootstrap oidc config.
Attempts to fix #1294; Earlier, it was working locally but there is still an issue in dev env