### PR TITLE
Add Cookie Information and Matomo Analytics behind feature flags

### DIFF
--- a/src/config/FeatureFlags.ts
+++ b/src/config/FeatureFlags.ts
@@ -3,6 +3,7 @@ export type FeatureFlags = {
   KartverketFlyFotoLayer: boolean;
   Fintraffic: boolean;
   CookieInformation: boolean;
+  MatomoTracker: boolean;
 };
 
 export type Features = keyof FeatureFlags;

--- a/src/config/FeatureFlags.ts
+++ b/src/config/FeatureFlags.ts
@@ -2,6 +2,7 @@ export type FeatureFlags = {
   SVVStreetViewLink: boolean;
   KartverketFlyFotoLayer: boolean;
   Fintraffic: boolean;
+  CookieInformation: boolean;
 };
 
 export type Features = keyof FeatureFlags;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -94,6 +94,7 @@ const App = ({ children }) => {
       <Helmet>
         <html lang={localization.locale} />
       </Helmet>
+      <ComponentToggle feature="CookieInformation" />
       <StyledEngineProvider injectFirst>
         <ComponentToggle
           feature={`${extPath}/CustomThemeProvider`}

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -95,6 +95,7 @@ const App = ({ children }) => {
         <html lang={localization.locale} />
       </Helmet>
       <ComponentToggle feature="CookieInformation" />
+      <ComponentToggle feature="MatomoTracker" />
       <StyledEngineProvider injectFirst>
         <ComponentToggle
           feature={`${extPath}/CustomThemeProvider`}

--- a/src/ext/CookieInformation/CookieInformation.tsx
+++ b/src/ext/CookieInformation/CookieInformation.tsx
@@ -1,0 +1,17 @@
+import { Helmet } from "react-helmet";
+import { useIntl } from "react-intl";
+
+export const CookieInformation = () => {
+  const { locale } = useIntl();
+
+  return (
+    <Helmet>
+      <script
+        data-culture={locale.toUpperCase()}
+        id="CookieConsent"
+        src={"https://policy.app.cookieinformation.com/uc.js"}
+        type="text/javascript"
+      />
+    </Helmet>
+  );
+};

--- a/src/ext/CookieInformation/README.md
+++ b/src/ext/CookieInformation/README.md
@@ -1,0 +1,17 @@
+# Cookie Information based cookies consent management
+
+Cookie Information to collect user consent for cookies and tracking. More info: https://cookieinformation.com/
+
+## Enabling the feature
+
+Once enabled in bootstrap.json
+
+    "featureFlags": {
+        "CookieInformation": true
+    }
+
+CookieInformation feature can be wired in as:
+
+    <ComponentToggle
+        feature="CookieInformation"
+    />

--- a/src/ext/CookieInformation/index.ts
+++ b/src/ext/CookieInformation/index.ts
@@ -1,0 +1,2 @@
+import { CookieInformation } from "./CookieInformation";
+export default CookieInformation;

--- a/src/ext/MatomoTracker/MatomoTracker.tsx
+++ b/src/ext/MatomoTracker/MatomoTracker.tsx
@@ -1,0 +1,24 @@
+import { Helmet } from "react-helmet";
+import { useConfig } from "../../config/ConfigContext";
+import { MatomoConfig } from "./types";
+
+export const MatomoTracker = () => {
+  const { matomo } = useConfig() as MatomoConfig;
+
+  const matomoInitScript = `     
+    var _mtm = window._mtm = window._mtm || [];  
+    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+    (function() {
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='${matomo?.src}'; s.parentNode.insertBefore(g,s);
+    })();
+  `;
+
+  return matomo?.src ? (
+    <Helmet>
+      <script>{matomoInitScript}</script>
+    </Helmet>
+  ) : (
+    <></>
+  );
+};

--- a/src/ext/MatomoTracker/README.md
+++ b/src/ext/MatomoTracker/README.md
@@ -1,0 +1,27 @@
+# Matomo Analytics
+
+Matomo Analytics is a web analytics tool. More info: https://matomo.org/
+
+## Enabling the feature
+
+Once enabled in bootstrap.json with:
+
+    "featureFlags": {
+        "MatomoTracker": true
+    }
+
+As well as tracker configuration provided in bootstrap.json with:
+
+    "matomo": {
+        "src": "<url with Matomo script>",
+    }
+
+MatomoTracker feature can be wired in as:
+
+    <ComponentToggle
+        feature="MatomoTracker"
+    />
+
+## Cookie consent management
+
+Cookie consent can be managed, for example, by using the CookieInformation feature.

--- a/src/ext/MatomoTracker/index.ts
+++ b/src/ext/MatomoTracker/index.ts
@@ -1,0 +1,2 @@
+import { MatomoTracker } from "./MatomoTracker";
+export default MatomoTracker;

--- a/src/ext/MatomoTracker/types.ts
+++ b/src/ext/MatomoTracker/types.ts
@@ -1,0 +1,7 @@
+import { Config } from "../../config/ConfigContext";
+
+export interface MatomoConfig extends Config {
+  matomo: {
+    src: string;
+  };
+}


### PR DESCRIPTION
# Changes

1. Add Cookie Information as an external feature behind a feature flag
2. Add Matomo Analytics as an external feature behind a feature flag