### PR TITLE
Add more logic for facilities equipment availability checks

### DIFF
--- a/src/components/EditStopPage/FacilitiesQuayTab.js
+++ b/src/components/EditStopPage/FacilitiesQuayTab.js
@@ -156,10 +156,12 @@ class FacilitiesQuayTab extends React.Component {
     const { formatMessage } = intl;
     const { expandedIndex } = this.state;
 
-    const ticketMachine = equipmentHelpers.getTicketMachineState(quay);
-    const busShelter = equipmentHelpers.getShelterEquipmentState(quay);
-    const waitingRoom = equipmentHelpers.getWaitingRoomState(quay);
-    const WC = equipmentHelpers.getSanitaryEquipmentState(quay);
+    const isTicketMachinePresent =
+      equipmentHelpers.isTicketMachinePresent(quay);
+    const isBusShelterPresent =
+      equipmentHelpers.isShelterEquipmentPresent(quay);
+    const isWaitingRoomPresent = equipmentHelpers.isWaitingRoomPresent(quay);
+    const isWCPresent = equipmentHelpers.isSanitaryEquipmentPresent(quay);
 
     const ticketMachineNumber = getIn(
       quay,
@@ -196,7 +198,7 @@ class FacilitiesQuayTab extends React.Component {
       ["placeEquipments", "waitingRoomEquipment", "stepFree"],
       false,
     );
-    const sign512 = equipmentHelpers.get512SignEquipment(quay);
+    const isSign512Present = equipmentHelpers.is512SignEquipmentPresent(quay);
 
     return (
       <div style={{ padding: 10 }}>
@@ -205,7 +207,7 @@ class FacilitiesQuayTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={sign512}
+                  checked={isSign512Present}
                   checkedIcon={<Sign512 />}
                   disabled={disabled}
                   icon={
@@ -223,7 +225,7 @@ class FacilitiesQuayTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {sign512
+                  {isSign512Present
                     ? formatMessage({ id: "transport_sign" })
                     : formatMessage({ id: "transport_sign_no" })}
                 </div>
@@ -240,7 +242,7 @@ class FacilitiesQuayTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={ticketMachine}
+                  checked={isTicketMachinePresent}
                   checkedIcon={<TicketMachine style={{ fill: "#000" }} />}
                   icon={
                     <TicketMachine
@@ -255,7 +257,7 @@ class FacilitiesQuayTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {ticketMachine
+                  {isTicketMachinePresent
                     ? formatMessage({ id: "ticketMachine" })
                     : formatMessage({ id: "ticketMachine_no" })}
                 </div>
@@ -305,7 +307,7 @@ class FacilitiesQuayTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={busShelter}
+                  checked={isBusShelterPresent}
                   checkedIcon={<BusShelter style={{ fill: "#000" }} />}
                   icon={
                     <BusShelter style={{ fill: "#8c8c8c", opacity: "0.8" }} />
@@ -317,7 +319,7 @@ class FacilitiesQuayTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {busShelter
+                  {isBusShelterPresent
                     ? formatMessage({ id: "busShelter" })
                     : formatMessage({ id: "busShelter_no" })}
                 </div>
@@ -427,7 +429,7 @@ class FacilitiesQuayTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={WC}
+                  checked={isWCPresent}
                   checkedIcon={<MdWc style={{ fill: "#000" }} />}
                   icon={<MdWc style={{ fill: "#8c8c8c", opacity: "0.8" }} />}
                   labelStyle={{ fontSize: "0.8em" }}
@@ -438,7 +440,7 @@ class FacilitiesQuayTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {WC
+                  {isWCPresent
                     ? formatMessage({ id: "wc" })
                     : formatMessage({ id: "wc_no" })}
                 </div>
@@ -453,7 +455,7 @@ class FacilitiesQuayTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={waitingRoom}
+                  checked={isWaitingRoomPresent}
                   checkedIcon={<WaitingRoom style={{ fill: "#000" }} />}
                   icon={
                     <WaitingRoom style={{ fill: "#8c8c8c", opacity: "0.8" }} />
@@ -465,7 +467,7 @@ class FacilitiesQuayTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {waitingRoom
+                  {isWaitingRoomPresent
                     ? formatMessage({ id: "waiting_room" })
                     : formatMessage({ id: "waiting_room_no" })}
                 </div>

--- a/src/components/EditStopPage/FacilitiesStopTab.js
+++ b/src/components/EditStopPage/FacilitiesStopTab.js
@@ -181,11 +181,15 @@ class FacilitiesStopTab extends React.Component {
     const { formatMessage } = intl;
     const { expandedIndex } = this.state;
 
-    const ticketMachine = equiptmentHelpers.getTicketMachineState(stopPlace);
-    const busShelter = equiptmentHelpers.getShelterEquipmentState(stopPlace);
-    const waitingRoom = equiptmentHelpers.getWaitingRoomState(stopPlace);
-    const WC = equiptmentHelpers.getSanitaryEquipmentState(stopPlace);
-    const sign512 = equiptmentHelpers.get512SignEquipment(stopPlace);
+    const isTicketMachinePresent =
+      equiptmentHelpers.isTicketMachinePresent(stopPlace);
+    const isBusShelterPresent =
+      equiptmentHelpers.isShelterEquipmentPresent(stopPlace);
+    const isWaitingRoomPresent =
+      equiptmentHelpers.isWaitingRoomPresent(stopPlace);
+    const isWCPresent = equiptmentHelpers.isSanitaryEquipmentPresent(stopPlace);
+    const isSign512Present =
+      equiptmentHelpers.is512SignEquipmentPresent(stopPlace);
 
     console.log(stopPlace);
 
@@ -232,7 +236,7 @@ class FacilitiesStopTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={sign512}
+                  checked={isSign512Present}
                   checkedIcon={<TransportSign style={{ fill: "#000" }} />}
                   icon={
                     <TransportSign
@@ -250,7 +254,7 @@ class FacilitiesStopTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {sign512
+                  {isSign512Present
                     ? formatMessage({ id: "transport_sign" })
                     : formatMessage({ id: "transport_sign_no" })}
                 </div>
@@ -265,7 +269,7 @@ class FacilitiesStopTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={ticketMachine}
+                  checked={isTicketMachinePresent}
                   checkedIcon={<TicketMachine style={{ fill: "#000" }} />}
                   icon={
                     <TicketMachine
@@ -279,7 +283,7 @@ class FacilitiesStopTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {ticketMachine
+                  {isTicketMachinePresent
                     ? formatMessage({ id: "ticketMachine" })
                     : formatMessage({ id: "ticketMachine_no" })}
                 </div>
@@ -329,7 +333,7 @@ class FacilitiesStopTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={busShelter}
+                  checked={isBusShelterPresent}
                   checkedIcon={<BusShelter style={{ fill: "#000" }} />}
                   icon={
                     <BusShelter style={{ fill: "#8c8c8c", opacity: "0.8" }} />
@@ -341,7 +345,7 @@ class FacilitiesStopTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {busShelter
+                  {isBusShelterPresent
                     ? formatMessage({ id: "busShelter" })
                     : formatMessage({ id: "busShelter_no" })}
                 </div>
@@ -462,7 +466,7 @@ class FacilitiesStopTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={WC}
+                  checked={isWCPresent}
                   checkedIcon={<MdWc style={{ fill: "#000" }} />}
                   icon={<MdWc style={{ fill: "#8c8c8c", opacity: "0.8" }} />}
                   onChange={(e, v) => {
@@ -472,7 +476,7 @@ class FacilitiesStopTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {WC
+                  {isWCPresent
                     ? formatMessage({ id: "wc" })
                     : formatMessage({ id: "wc_no" })}
                 </div>
@@ -487,7 +491,7 @@ class FacilitiesStopTab extends React.Component {
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={waitingRoom}
+                  checked={isWaitingRoomPresent}
                   checkedIcon={<WaitingRoom style={{ fill: "#000" }} />}
                   icon={
                     <WaitingRoom style={{ fill: "#8c8c8c", opacity: "0.8" }} />
@@ -499,7 +503,7 @@ class FacilitiesStopTab extends React.Component {
               }
               label={
                 <div style={{ fontSize: "0.8em" }}>
-                  {waitingRoom
+                  {isWaitingRoomPresent
                     ? formatMessage({ id: "waiting_room" })
                     : formatMessage({ id: "waiting_room_no" })}
                 </div>

--- a/src/components/EditStopPage/QuayItem.js
+++ b/src/components/EditStopPage/QuayItem.js
@@ -167,20 +167,22 @@ class QuayItem extends React.Component {
       ["accessibilityAssessment", "limitations", "stepFreeAccess"],
       "UNKNOWN",
     );
-    const ticketMachine = equipmentHelpers.getTicketMachineState(quay);
-    const busShelter = equipmentHelpers.getShelterEquipmentState(quay);
-    const sign512 = equipmentHelpers.get512SignEquipment(quay);
+    const isTicketMachinePresent =
+      equipmentHelpers.isTicketMachinePresent(quay);
+    const isBusShelterPresent =
+      equipmentHelpers.isShelterEquipmentPresent(quay);
+    const isSign512Present = equipmentHelpers.is512SignEquipmentPresent(quay);
 
     const wheelChairHint = formatMessage({
       id: `accessibilityAssessments_wheelchairAccess_${wheelchairAccess.toLowerCase()}`,
     });
-    const ticketMachineHint = ticketMachine
+    const ticketMachineHint = isTicketMachinePresent
       ? formatMessage({ id: "ticketMachine" })
       : formatMessage({ id: "ticketMachine_no" });
-    const busShelterHint = busShelter
+    const busShelterHint = isBusShelterPresent
       ? formatMessage({ id: "busShelter" })
       : formatMessage({ id: "busShelter_no" });
-    const transportSignHint = sign512
+    const transportSignHint = isSign512Present
       ? formatMessage({ id: "transport_sign" })
       : formatMessage({ id: "transport_sign_no" });
     const stepFreeHint = formatMessage({
@@ -336,7 +338,7 @@ class QuayItem extends React.Component {
                       />
                     }
                     style={{ width: "auto" }}
-                    checked={ticketMachine}
+                    checked={isTicketMachinePresent}
                     onChange={(e, v) => {
                       this.handleTicketMachineChange(v);
                     }}
@@ -350,7 +352,7 @@ class QuayItem extends React.Component {
                       <BusShelter style={{ fill: "#8c8c8c", opacity: "0.8" }} />
                     }
                     style={{ width: "auto" }}
-                    checked={busShelter}
+                    checked={isBusShelterPresent}
                     onChange={(e, v) => {
                       this.handleBusShelterChange(v);
                     }}
@@ -369,7 +371,7 @@ class QuayItem extends React.Component {
                       />
                     }
                     style={{ width: "auto" }}
-                    checked={sign512}
+                    checked={isSign512Present}
                     onChange={(event, v) => {
                       this.handleTransportSignChange(v);
                     }}

--- a/src/components/EditStopPage/StopPlaceDetails.js
+++ b/src/components/EditStopPage/StopPlaceDetails.js
@@ -394,11 +394,14 @@ class StopPlaceDetails extends React.Component {
       "UNKNOWN",
     );
 
-    const ticketMachine = equipmentHelpers.getTicketMachineState(stopPlace);
-    const busShelter = equipmentHelpers.getShelterEquipmentState(stopPlace);
-    const waitingRoom = equipmentHelpers.getWaitingRoomState(stopPlace);
-    const WC = equipmentHelpers.getSanitaryEquipmentState(stopPlace);
-    const sign512 = equipmentHelpers.get512SignEquipment(stopPlace);
+    const isTicketMachinePresent =
+      equipmentHelpers.isTicketMachinePresent(stopPlace);
+    const isBusShelterPresent =
+      equipmentHelpers.isShelterEquipmentPresent(stopPlace);
+    const isWaitingRoomPresent =
+      equipmentHelpers.isWaitingRoomPresent(stopPlace);
+    const isWCPresent = equipmentHelpers.isSanitaryEquipmentPresent(stopPlace);
+    const isSign512 = equipmentHelpers.is512SignEquipmentPresent(stopPlace);
 
     const hasAltNames = !!(
       stopPlace.alternativeNames && stopPlace.alternativeNames.length
@@ -418,19 +421,19 @@ class StopPlaceDetails extends React.Component {
     const wheelChairHint = formatMessage({
       id: `accessibilityAssessments_wheelchairAccess_${wheelchairAccess.toLowerCase()}`,
     });
-    const ticketMachineHint = ticketMachine
+    const ticketMachineHint = isTicketMachinePresent
       ? formatMessage({ id: "ticketMachine" })
       : formatMessage({ id: "ticketMachine_no" });
-    const busShelterHint = busShelter
+    const busShelterHint = isBusShelterPresent
       ? formatMessage({ id: "busShelter" })
       : formatMessage({ id: "busShelter_no" });
-    const WCHint = WC
+    const WCHint = isWCPresent
       ? formatMessage({ id: "wc" })
       : formatMessage({ id: "wc_no" });
-    const waitingRoomHint = waitingRoom
+    const waitingRoomHint = isWaitingRoomPresent
       ? formatMessage({ id: "waiting_room" })
       : formatMessage({ id: "waiting_room_no" });
-    const transportSignHint = sign512
+    const transportSignHint = isSign512
       ? formatMessage({ id: "transport_sign" })
       : formatMessage({ id: "transport_sign_no" });
     const tariffZonesHint = formatMessage({ id: "tariffZones" });
@@ -724,7 +727,7 @@ class StopPlaceDetails extends React.Component {
                   <TicketMachine style={{ fill: "#8c8c8c", opacity: "0.8" }} />
                 }
                 style={{ width: "auto" }}
-                checked={ticketMachine}
+                checked={isTicketMachinePresent}
                 onChange={(e, v) => {
                   this.handleTicketMachineChange(v);
                 }}
@@ -737,7 +740,7 @@ class StopPlaceDetails extends React.Component {
                   <BusShelter style={{ fill: "#8c8c8c", opacity: "0.8" }} />
                 }
                 style={{ width: "auto" }}
-                checked={busShelter}
+                checked={isBusShelterPresent}
                 onChange={(e, v) => {
                   this.handleBusShelterChange(v);
                 }}
@@ -748,7 +751,7 @@ class StopPlaceDetails extends React.Component {
                 checkedIcon={<MdWC style={{ fill: "#000" }} />}
                 icon={<MdWC style={{ fill: "#8c8c8c", opacity: "0.8" }} />}
                 style={{ width: "auto" }}
-                checked={WC}
+                checked={isWCPresent}
                 onChange={(e, v) => {
                   this.handleWCChange(v);
                 }}
@@ -761,7 +764,7 @@ class StopPlaceDetails extends React.Component {
                   <WaitingRoom style={{ fill: "#8c8c8c", opacity: "0.8" }} />
                 }
                 style={{ width: "auto" }}
-                checked={waitingRoom}
+                checked={isWaitingRoomPresent}
                 onChange={(e, v) => {
                   this.handleWaitingRoomChange(v);
                 }}
@@ -779,7 +782,7 @@ class StopPlaceDetails extends React.Component {
                 }
                 checkedIcon={<TransportSign />}
                 style={{ width: "auto" }}
-                checked={sign512}
+                checked={isSign512}
                 onChange={(e, v) => {
                   this.handleChangeSign512(v);
                 }}

--- a/src/modelUtils/equipmentHelpers.js
+++ b/src/modelUtils/equipmentHelpers.js
@@ -17,34 +17,28 @@ import { getIn } from "../utils";
 
 const EquipmentHelpers = {};
 
-EquipmentHelpers.getTicketMachineState = (entity) => {
-  const equipmentState = getIn(
+EquipmentHelpers.isTicketMachinePresent = (entity) => {
+  return getIn(
     entity,
-    ["placeEquipments", "ticketingEquipment"],
+    ["placeEquipments", "ticketingEquipment", "ticketMachines"],
     null,
   );
-  return equipmentState !== null;
 };
 
-EquipmentHelpers.getShelterEquipmentState = (entity) => {
-  const equipmentState = getIn(
-    entity,
-    ["placeEquipments", "shelterEquipment"],
-    null,
-  );
-  return equipmentState !== null;
+EquipmentHelpers.isShelterEquipmentPresent = (entity) => {
+  return getIn(entity, ["placeEquipments", "shelterEquipment", "seats"], null);
 };
 
-EquipmentHelpers.getSanitaryEquipmentState = (entity) => {
+EquipmentHelpers.isSanitaryEquipmentPresent = (entity) => {
   const sanitaryState = getIn(
     entity,
-    ["placeEquipments", "sanitaryEquipment"],
+    ["placeEquipments", "sanitaryEquipment", "numberOfToilets"],
     null,
   );
   return sanitaryState !== null;
 };
 
-EquipmentHelpers.get512SignEquipment = (entity) => {
+EquipmentHelpers.is512SignEquipmentPresent = (entity) => {
   const generalSign = getIn(entity, ["placeEquipments", "generalSign"], null);
   if (
     generalSign &&
@@ -62,22 +56,20 @@ EquipmentHelpers.update512SignEquipment = (entity, payload) => {
   return updateEquipmentForEntitity(copyOfEntity, payload, types.generalSign);
 };
 
-EquipmentHelpers.getWaitingRoomState = (entity) => {
-  const waitingRoomState = getIn(
+EquipmentHelpers.isWaitingRoomPresent = (entity) => {
+  return getIn(
     entity,
-    ["placeEquipments", "waitingRoomEquipment"],
+    ["placeEquipments", "waitingRoomEquipment", "seats"],
     null,
   );
-  return waitingRoomState !== null;
 };
 
-EquipmentHelpers.getCycleStorageEquipment = (entity) => {
-  const cycleStorageState = getIn(
+EquipmentHelpers.isCycleStorageEquipmentPresent = (entity) => {
+  return getIn(
     entity,
-    ["placeEquipments", "cycleStorageEquipment"],
+    ["placeEquipments", "cycleStorageEquipment", "numberOfSpaces"],
     null,
   );
-  return cycleStorageState !== null;
 };
 
 EquipmentHelpers.updateTicketMachineState = (stopPlace, payload) => {

--- a/src/modelUtils/equipmentHelpers.js
+++ b/src/modelUtils/equipmentHelpers.js
@@ -18,7 +18,7 @@ import { getIn } from "../utils";
 const EquipmentHelpers = {};
 
 EquipmentHelpers.isTicketMachinePresent = (entity) => {
-  return getIn(
+  return !!getIn(
     entity,
     ["placeEquipments", "ticketingEquipment", "ticketMachines"],
     null,
@@ -26,16 +26,19 @@ EquipmentHelpers.isTicketMachinePresent = (entity) => {
 };
 
 EquipmentHelpers.isShelterEquipmentPresent = (entity) => {
-  return getIn(entity, ["placeEquipments", "shelterEquipment", "seats"], null);
+  return !!getIn(
+    entity,
+    ["placeEquipments", "shelterEquipment", "seats"],
+    null,
+  );
 };
 
 EquipmentHelpers.isSanitaryEquipmentPresent = (entity) => {
-  const sanitaryState = getIn(
+  return !!getIn(
     entity,
     ["placeEquipments", "sanitaryEquipment", "numberOfToilets"],
     null,
   );
-  return sanitaryState !== null;
 };
 
 EquipmentHelpers.is512SignEquipmentPresent = (entity) => {
@@ -57,7 +60,7 @@ EquipmentHelpers.update512SignEquipment = (entity, payload) => {
 };
 
 EquipmentHelpers.isWaitingRoomPresent = (entity) => {
-  return getIn(
+  return !!getIn(
     entity,
     ["placeEquipments", "waitingRoomEquipment", "seats"],
     null,
@@ -65,7 +68,7 @@ EquipmentHelpers.isWaitingRoomPresent = (entity) => {
 };
 
 EquipmentHelpers.isCycleStorageEquipmentPresent = (entity) => {
-  return getIn(
+  return !!getIn(
     entity,
     ["placeEquipments", "cycleStorageEquipment", "numberOfSpaces"],
     null,

--- a/src/test/equipment.spec.js
+++ b/src/test/equipment.spec.js
@@ -25,50 +25,50 @@ equiptedStopPlace.placeEquipments = simplifyPlaceEquipment(
 
 describe("equipment helper", () => {
   test("should give binary representation of ticket machine based on data", () => {
-    const first = helpers.getTicketMachineState(equiptedStopPlace);
+    const first = helpers.isTicketMachinePresent(equiptedStopPlace);
     expect(first).toEqual(true);
 
-    const second = helpers.getTicketMachineState(unequiptedStopPlace);
+    const second = helpers.isTicketMachinePresent(unequiptedStopPlace);
     expect(second).toEqual(false);
   });
 
   test("should give binary representation of shelterEquipment based on data", () => {
-    const first = helpers.getShelterEquipmentState(equiptedStopPlace);
+    const first = helpers.isShelterEquipmentPresent(equiptedStopPlace);
     expect(first).toEqual(true);
 
-    const second = helpers.getShelterEquipmentState(unequiptedStopPlace);
+    const second = helpers.isShelterEquipmentPresent(unequiptedStopPlace);
     expect(second).toEqual(false);
   });
 
   test("should give binary representation of sanitaryEquipment based on data", () => {
-    const first = helpers.getSanitaryEquipmentState(equiptedStopPlace);
+    const first = helpers.isSanitaryEquipmentPresent(equiptedStopPlace);
     expect(first).toEqual(true);
 
-    const second = helpers.getSanitaryEquipmentState(unequiptedStopPlace);
+    const second = helpers.isSanitaryEquipmentPresent(unequiptedStopPlace);
     expect(second).toEqual(false);
   });
 
   test("should give binary representation of waitingRoom based on data", () => {
-    const first = helpers.getWaitingRoomState(equiptedStopPlace);
+    const first = helpers.isWaitingRoomPresent(equiptedStopPlace);
     expect(first).toEqual(true);
 
-    const second = helpers.getWaitingRoomState(unequiptedStopPlace);
+    const second = helpers.isWaitingRoomPresent(unequiptedStopPlace);
     expect(second).toEqual(false);
   });
 
   test("should give binary representation of cycleStorageEquipment based on data", () => {
-    const first = helpers.getCycleStorageEquipment(equiptedStopPlace);
+    const first = helpers.isCycleStorageEquipmentPresent(equiptedStopPlace);
     expect(first).toEqual(true);
 
-    const second = helpers.getCycleStorageEquipment(unequiptedStopPlace);
+    const second = helpers.isCycleStorageEquipmentPresent(unequiptedStopPlace);
     expect(second).toEqual(false);
   });
 
   test("should give binary representation of sign512Equipment based on data", () => {
-    const first = helpers.get512SignEquipment(equiptedStopPlace);
+    const first = helpers.is512SignEquipmentPresent(equiptedStopPlace);
     expect(first).toEqual(true);
 
-    const second = helpers.get512SignEquipment(unequiptedStopPlace);
+    const second = helpers.is512SignEquipmentPresent(unequiptedStopPlace);
     expect(second).toEqual(false);
   });
 
@@ -84,7 +84,7 @@ describe("equipment helper", () => {
       payloadTrue,
     );
 
-    const equipted = helpers.get512SignEquipment(stopPlace);
+    const equipted = helpers.is512SignEquipmentPresent(stopPlace);
     expect(equipted).toEqual(true);
   });
 
@@ -98,7 +98,7 @@ describe("equipment helper", () => {
       equiptedStopPlace,
       payloadFalse,
     );
-    const unequipted = helpers.get512SignEquipment(stopPlace);
+    const unequipted = helpers.is512SignEquipmentPresent(stopPlace);
     expect(unequipted).toEqual(false);
   });
 
@@ -111,7 +111,7 @@ describe("equipment helper", () => {
       unEquiptedWith512Sign.quays.push(unequiptedStopPlace);
     }
 
-    let equiptedWith512 = helpers.get512SignEquipment(
+    let equiptedWith512 = helpers.is512SignEquipmentPresent(
       unEquiptedWith512Sign.quays[0],
     );
     expect(equiptedWith512).toEqual(false);
@@ -127,8 +127,10 @@ describe("equipment helper", () => {
       payloadTrue,
     );
 
-    const equiptedQuay = helpers.get512SignEquipment(stopPlace.quays[1]);
-    const unEquiptedQuay = helpers.get512SignEquipment(stopPlace.quays[0]);
+    const equiptedQuay = helpers.is512SignEquipmentPresent(stopPlace.quays[1]);
+    const unEquiptedQuay = helpers.is512SignEquipmentPresent(
+      stopPlace.quays[0],
+    );
     expect(equiptedQuay).toEqual(true);
     expect(unEquiptedQuay).toEqual(false);
   });


### PR DESCRIPTION
The PR tries to resolve the following problem:

- Originally, the "get" methods in the equipmentHelpers were relying on a `!= null` kind of check, which just checks whether an xml element is present or not. That causes some problems
- In case with ticket machine, the actual value in `<TicketMachines>false</TicketMachines>` can be false, which the current `!= null` check misses out on and then incorrectly shows the ticket machines as enabled in the UI
- Similar situation in other equipments, the `!= null` check doesn't explore further what's the content under the tag, which can result in showing some equipment as enabled in the UI, while there nothing under the tag that suggests it being enabled. For example: 
```
        <SanitaryEquipment id="FSR:SanitaryEquipment:2253" version="1">
            <Note></Note>
	    <SanitaryFacilityList></SanitaryFacilityList>
        </SanitaryEquipment>
```

In the scenarios other than TicketMachines,  `numberOfToilets`, `seats` and `numberOfSpaces` were taken as the indicators of whether something is enabled. Potentially, there could be other additional fields to consider along the way, but with the current db model those fields looked like the only ones available to use. When switching some type of equipment from true to false, those fields are the ones that get incremented from 0 to 1 (or if going the other way around - becoming a 0).