### PR TITLE
Add checks around permissions objects before accessing its fields

### DIFF
--- a/src/components/EditStopPage/EditStopGeneral.js
+++ b/src/components/EditStopPage/EditStopGeneral.js
@@ -843,7 +843,7 @@ const mapStateToProps = (state) => {
   const stopPlace = state.stopPlace.current;
   const permissions = getStopPermissions(stopPlace);
   return {
-    canDeleteStop: permissions.canDelete,
+    canDeleteStop: permissions?.canDelete,
     stopPlace,
     mergeStopDialogOpen: state.stopPlace.mergeStopDialog
       ? state.stopPlace.mergeStopDialog.isOpen
@@ -868,7 +868,7 @@ const mapStateToProps = (state) => {
     movingQuay: state.mapUtils.movingQuay,
     movingQuayToNewStop: state.mapUtils.movingQuayToNewStop,
     activeMap: state.mapUtils.activeMap,
-    canEditParentStop: permissions.canEditParentStop || false,
+    canEditParentStop: permissions?.canEditParentStop || false,
     originalStopPlace: state.stopPlace.originalCurrent,
     serverTimeDiff: state.user.serverTimeDiff,
     isFetchingMergeInfo: state.stopPlace.isFetchingMergeInfo,

--- a/src/components/Map/MarkerList.js
+++ b/src/components/Map/MarkerList.js
@@ -228,7 +228,7 @@ class MarkerList extends React.Component {
               isMultimodalChild={false}
               isGroupMember={true}
               disabled={disabled}
-              canEdit={member.permissions.canEdit}
+              canEdit={member.permissions?.canEdit}
               handleDragEnd={() => {}}
               active={true}
               stopType={member.stopPlaceType}
@@ -287,7 +287,7 @@ class MarkerList extends React.Component {
                   isMultimodal={false}
                   isMultimodalChild={true}
                   disabled={disabled}
-                  canEdit={child.permissions.canEdit}
+                  canEdit={child.permissions?.canEdit}
                   handleDragEnd={handleDragEnd}
                   active={false}
                   stopType={child.stopPlaceType}
@@ -357,7 +357,7 @@ class MarkerList extends React.Component {
               formattedStopType={localeStopType}
               isMultimodal={marker.isParent}
               disabled={disabled}
-              canEdit={marker.permissions.canEdit}
+              canEdit={marker.permissions?.canEdit}
               handleDragEnd={handleDragEnd}
               active={!!marker.isActive}
               stopType={marker.stopPlaceType}

--- a/src/utils/permissionsUtils.js
+++ b/src/utils/permissionsUtils.js
@@ -15,19 +15,19 @@
 import stopTypes from "../models/stopTypes";
 
 const buildAllowanceInfo = (permissions) => {
-  const canEdit = permissions.canEdit;
-  const canDeleteStop = permissions.canDelete;
+  const canEdit = permissions?.canEdit;
+  const canDeleteStop = permissions?.canDelete;
 
   let legalStopPlaceTypes = getLegalStopPlacesTypes(
-    permissions.allowedStopPlaceTypes || [],
-    permissions.bannedStopPlaceTypes || [],
+    permissions?.allowedStopPlaceTypes || [],
+    permissions?.bannedStopPlaceTypes || [],
   );
   let legalSubmodes = getLegalSubmodes(permissions);
 
   return {
     legalStopPlaceTypes,
     legalSubmodes,
-    blacklistedStopPlaceTypes: permissions.bannedStopPlaceTypes || [],
+    blacklistedStopPlaceTypes: permissions?.bannedStopPlaceTypes || [],
     canEdit,
     canDeleteStop,
   };
@@ -100,7 +100,7 @@ const getSubmodesForStopType = (stopType, permissions) => {
   const { submodes } = stopTypes[stopType];
   if (!submodes) return [];
 
-  if (permissions.bannedStopPlaceTypes.includes(stopType)) return [];
+  if (permissions?.bannedStopPlaceTypes.includes(stopType)) return [];
   if (!isStopTypeAllowed(stopType, permissions)) return [];
 
   return submodes;


### PR DESCRIPTION
Before was possible to hit a case when `permissions` is undefined and accessing its `canEdit` field caused UI to crash with a white screen