### PR TITLE
Update about-to-be-created stop place permissions if its marker's location changes

### DIFF
--- a/src/actions/StopPlaceActions.js
+++ b/src/actions/StopPlaceActions.js
@@ -50,11 +50,24 @@ StopPlaceActions.addChildrenToParenStopPlace =
     dispatch(createThunk(types.ADDED_STOP_PLACES_TO_PARENT, toAdd));
   };
 
-StopPlaceActions.changeLocationNewStop = (location) => (dispatch) => {
-  dispatch(
-    createThunk(types.CHANGED_LOCATION_NEW_STOP, [location.lat, location.lng]),
-  );
-};
+StopPlaceActions.changeLocationNewStop =
+  (location) => async (dispatch, getState) => {
+    // First get location permissions
+    await dispatch(
+      getLocationPermissionsForCoordinates(location.lng, location.lat),
+    );
+
+    // Get updated state after permissions are fetched
+    const updatedState = getState();
+    const locationPermissions = updatedState.user?.locationPermissions || {};
+
+    dispatch(
+      createThunk(types.CHANGED_LOCATION_NEW_STOP, {
+        location: [location.lat, location.lng],
+        locationPermissions,
+      }),
+    );
+  };
 
 StopPlaceActions.sortQuays = (attribute) => (dispatch) => {
   dispatch(createThunk(types.SORTED_QUAYS, attribute));

--- a/src/actions/StopPlaceActions.js
+++ b/src/actions/StopPlaceActions.js
@@ -257,13 +257,24 @@ StopPlaceActions.changePrivateCodeName = (index, name, type) => (dispatch) => {
   );
 };
 
-StopPlaceActions.changeCurrentStopPosition = (position) => (dispatch) => {
-  dispatch(
-    createThunk(types.CHANGED_ACTIVE_STOP_POSITION, {
-      location: position,
-    }),
-  );
-};
+StopPlaceActions.changeCurrentStopPosition =
+  (position) => async (dispatch, getState) => {
+    // First get location permissions
+    await dispatch(
+      getLocationPermissionsForCoordinates(position[1], position[0]),
+    );
+
+    // Get updated state after permissions are fetched
+    const updatedState = getState();
+    const locationPermissions = updatedState.user?.locationPermissions || {};
+
+    dispatch(
+      createThunk(types.CHANGED_ACTIVE_STOP_POSITION, {
+        location: position,
+        locationPermissions,
+      }),
+    );
+  };
 
 StopPlaceActions.changeWeightingForStop = (value) => (dispatch) => {
   dispatch(createThunk(types.CHANGED_WEIGHTING_STOP_PLACE, value));

--- a/src/actions/StopPlaceActions.js
+++ b/src/actions/StopPlaceActions.js
@@ -168,7 +168,7 @@ StopPlaceActions.setMarkerOnMap = (data) => (dispatch, getState) => {
 
   const { location } = data;
   if (location) {
-    dispatch(getLocationPermissionsForCoordinates(location[0], location[1]));
+    dispatch(getLocationPermissionsForCoordinates(location[1], location[0]));
   }
 
   if (data.entityType === Entities.STOP_PLACE) {

--- a/src/modelUtils/mapToClient.js
+++ b/src/modelUtils/mapToClient.js
@@ -557,9 +557,14 @@ helpers.updateCurrentStopWithSubMode = (
   });
 };
 
-helpers.updateCurrentStopWithPosition = (current, location) => {
+helpers.updateCurrentStopWithPositionAndPermissions = (
+  current,
+  location,
+  permissions,
+) => {
   return Object.assign({}, current, {
-    location: location,
+    location,
+    permissions,
   });
 };
 

--- a/src/reducers/stopPlaceReducer.js
+++ b/src/reducers/stopPlaceReducer.js
@@ -315,14 +315,18 @@ const stopPlaceReducer = (state = initialState, action) => {
         stopHasBeenModified: true,
       });
 
-    case types.CHANGED_ACTIVE_STOP_POSITION:
+    case types.CHANGED_ACTIVE_STOP_POSITION: {
+      const { location, locationPermissions } = action.payload;
+
       return Object.assign({}, state, {
-        current: formatHelpers.updateCurrentStopWithPosition(
+        current: formatHelpers.updateCurrentStopWithPositionAndPermissions(
           state.current,
-          action.payload.location,
+          location,
+          locationPermissions,
         ),
         stopHasBeenModified: true,
       });
+    }
 
     case types.USE_NEW_STOP_AS_CURRENT:
       return Object.assign({}, state, {

--- a/src/reducers/stopPlaceReducer.js
+++ b/src/reducers/stopPlaceReducer.js
@@ -185,7 +185,7 @@ const stopPlaceReducer = (state = initialState, action) => {
         stopHasBeenModified: true,
       });
 
-    case types.CREATED_NEW_STOP:
+    case types.CREATED_NEW_STOP: {
       const { location, isMultimodal, locationPermissions } = action.payload;
       const stopToBeCreated = isMultimodal
         ? formatHelpers.createNewParentStopFromLocation(location)
@@ -202,7 +202,7 @@ const stopPlaceReducer = (state = initialState, action) => {
         newStopIsMultiModal: isMultimodal,
         stopHasBeenModified: false,
       });
-
+    }
     case types.CHANGED_QUAY_COMPASS_BEARING:
       return Object.assign({}, state, {
         current: formatHelpers.updateCompassBearing(
@@ -244,12 +244,17 @@ const stopPlaceReducer = (state = initialState, action) => {
         stopHasBeenModified: true,
       });
 
-    case types.CHANGED_LOCATION_NEW_STOP:
+    case types.CHANGED_LOCATION_NEW_STOP: {
+      const { location, locationPermissions } = action.payload;
+      const newStop = formatHelpers.createNewStopFromLocation(location);
       return Object.assign({}, state, {
-        newStop: formatHelpers.createNewStopFromLocation(action.payload),
+        newStop: {
+          ...newStop,
+          permissions: locationPermissions,
+        },
         stopHasBeenModified: true,
       });
-
+    }
     case types.CHANGED_STOP_NAME:
       return {
         ...state,


### PR DESCRIPTION
There was an issue that can be reproduced like this:

- Create new stop, double-click on the map to place the marker
- Move the marker's location
- Proceed to create the stop at that changed location
- The resulting stop place creation form will have text inputs in a disabled state

Fix: update permissions for the new marker location