### PR TITLE
fix: use search result permissions for edit button display

### DIFF
--- a/src/components/MainPage/SearchBox.js
+++ b/src/components/MainPage/SearchBox.js
@@ -35,9 +35,11 @@ import { StopPlaceActions, UserActions } from "../../actions/";
 import {
   findEntitiesWithFilters,
   findTopographicalPlace,
+  getStopPlaceById,
 } from "../../actions/TiamatActions";
 import { getPrimaryDarkerColor } from "../../config/themeConfig";
 import { Entities } from "../../models/Entities";
+import formatHelpers from "../../modelUtils/mapToClient";
 import Routes from "../../routes/";
 import FavoriteManager from "../../singletons/FavoriteManager";
 import MdSpinner from "../../static/icons/spinner";
@@ -173,7 +175,25 @@ class SearchBox extends React.Component {
       typeof result.element !== "undefined" &&
       result.element !== null
     ) {
-      this.props.dispatch(StopPlaceActions.setMarkerOnMap(result.element));
+      // Load full stop place data instead of using limited search result data
+      const stopPlaceId = result.element.id;
+      if (stopPlaceId) {
+        this.props.dispatch(getStopPlaceById(stopPlaceId)).then(({ data }) => {
+          if (data.stopPlace && data.stopPlace.length) {
+            const stopPlaces = formatHelpers.mapSearchResultToStopPlaces(
+              data.stopPlace,
+            );
+            if (stopPlaces.length) {
+              this.props.dispatch(
+                StopPlaceActions.setMarkerOnMap(stopPlaces[0]),
+              );
+            }
+          }
+        });
+      } else {
+        // Fallback to original behavior if no ID
+        this.props.dispatch(StopPlaceActions.setMarkerOnMap(result.element));
+      }
       this.setState({ stopPlaceSearchValue: "" });
     }
   }


### PR DESCRIPTION
Fix edit stop place button showing "View" instead of "Edit" when user has editing rights. The button was using current stop place permissions instead of the search result's permissions.

- Check activeSearchResult permissions first, fallback to current stop place
- Ensures button text accurately reflects user's rights for each search result
- Resolves confusion where users with edit rights saw "View" button

Fixes #1337