### PR TITLE
Check for GOSP entity type before attempting to fetch stop place details

### DIFF
--- a/src/components/MainPage/SearchBox.js
+++ b/src/components/MainPage/SearchBox.js
@@ -177,7 +177,7 @@ class SearchBox extends React.Component {
     ) {
       // Load full stop place data instead of using limited search result data
       const stopPlaceId = result.element.id;
-      if (stopPlaceId) {
+      if (stopPlaceId && result.element.entityType !== "GROUP_OF_STOP_PLACE") {
         this.props.dispatch(getStopPlaceById(stopPlaceId)).then(({ data }) => {
           if (data.stopPlace && data.stopPlace.length) {
             const stopPlaces = formatHelpers.mapSearchResultToStopPlaces(


### PR DESCRIPTION
#1432 introduced a regression where it was no longer possible to select GOSPs from search results. This PR fixes that.