### PR TITLE
Missing stop place marker issue

### DIFF
--- a/src/components/EditStopPage/EditStopGeneral.js
+++ b/src/components/EditStopPage/EditStopGeneral.js
@@ -361,11 +361,21 @@ class EditStopGeneral extends React.Component {
       });
   }
 
-  handleGoBack() {
+  async handleGoBack() {
+    const { dispatch, activeMap } = this.props;
     this.setState({
       confirmGoBack: false,
     });
-    this.props.dispatch(UserActions.navigateTo("/", ""));
+    if (activeMap) {
+      await dispatch(
+        getNeighbourStops(
+          null,
+          activeMap.getBounds(),
+          new Settings().getShowExpiredStops(),
+        ),
+      );
+    }
+    dispatch(UserActions.navigateTo("/", ""));
   }
 
   handleAllowUserToGoBack() {


### PR DESCRIPTION
After leaving edit/view mode of a stop place the marker for that stop disappears. Fixes #1453