### PR TITLE
Use preferred username from user permissions query

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -37,7 +37,6 @@ import {
   toggleShowFareZonesInMap,
   toggleShowTariffZonesInMap,
 } from "../../reducers/zonesSlice";
-import { getIn } from "../../utils";
 import ConfirmDialog from "./../Dialogs/ConfirmDialog";
 import MoreMenuItem from "./../MainPage/MoreMenuItem";
 import { LanguageMenu } from "./LanguageMenu";
@@ -185,7 +184,7 @@ class Header extends React.Component {
     const reportSite = formatMessage({ id: "report_site" });
     const expiredStopLabel = formatMessage({ id: "show_expired_stops" });
     const userGuide = formatMessage({ id: "user_guide" });
-    const username = getIn(auth, ["user", "name"], "");
+    const username = this.props.preferredName || "";
     const showMultimodalEdgesLabel = formatMessage({
       id: "show_multimodal_edges",
     });
@@ -582,6 +581,7 @@ class Header extends React.Component {
 
 const mapStateToProps = (state) => ({
   auth: state.user.auth,
+  preferredName: state.user.preferredName,
   isCompassBearingEnabled: state.stopPlace.isCompassBearingEnabled,
   isDisplayingEditStopPlace:
     state.router.location.pathname.indexOf("/stop_place/") > -1,

--- a/src/graphql/Tiamat/queries.js
+++ b/src/graphql/Tiamat/queries.js
@@ -839,6 +839,7 @@ export const getUserPermissionsQuery = gql`
     userPermissions {
       allowNewStopEverywhere
       isGuest
+      preferredName
     }
   }
 `;

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -64,6 +64,7 @@ export const initialState = {
   auth: {},
   isGuest: true,
   allowNewStopEverywhere: false,
+  preferredName: "",
 };
 
 const userReducer = (state = initialState, action) => {
@@ -313,6 +314,7 @@ const userReducer = (state = initialState, action) => {
           isGuest: action.result.data.userPermissions.isGuest,
           allowNewStopEverywhere:
             action.result.data.userPermissions.allowNewStopEverywhere,
+          preferredName: action.result.data.userPermissions.preferredName || "",
         };
       } else if (action.operationName === "getLocationPermissions") {
         return {


### PR DESCRIPTION
Modernizes username retrieval by using the preferredName field from the GraphQL userPermissions query instead of extracting it from authentication tokens. This centralizes user data fetching and simplifies the
codebase.

The logout button text now displays the username from state.user.preferredName (populated by the GraphQL API) instead of auth.user.name (extracted from tokens). This follows the same data flow pattern as other user
permission fields like isGuest and allowNewStopEverywhere.

Closes #1463