### PR TITLE
Enable saving expired stops without requiring modifications.

### DIFF
--- a/src/components/EditParentStopPage/EditParentGeneral.js
+++ b/src/components/EditParentStopPage/EditParentGeneral.js
@@ -290,7 +290,7 @@ class EditParentGeneral extends React.Component {
     if (!stopPlace.id && !stopPlace.children.length) {
       return false;
     }
-    return stopHasBeenModified;
+    return stopHasBeenModified || stopPlace.hasExpired;
   }
 
   addAdjacentStopReference(stopPlaceId1, stopPlaceId2) {
@@ -411,7 +411,7 @@ class EditParentGeneral extends React.Component {
               </div>
             </FlatButton>
             <FlatButton
-              disabled={!stopHasBeenModified}
+              disabled={!stopHasBeenModified && !stopPlace.hasExpired}
               label={formatMessage({ id: "undo_changes" })}
               style={{ margin: "8 5", zIndex: 999, fontSize: "0.7em" }}
               onClick={() => {

--- a/src/components/EditStopPage/EditStopGeneral.js
+++ b/src/components/EditStopPage/EditStopGeneral.js
@@ -809,14 +809,17 @@ class EditStopGeneral extends React.Component {
               </FlatButton>
             )}
           <FlatButton
-            disabled={!stopHasBeenModified}
+            disabled={!stopHasBeenModified && !stopPlace.hasExpired}
             label={formatMessage({ id: "undo_changes" })}
             style={{
               margin: "8 5",
               zIndex: 999,
               minWidth: "120px",
               fontSize: "0.7em",
-              color: disabled || !stopHasBeenModified ? "#999" : "#000",
+              color:
+                disabled || (!stopHasBeenModified && !stopPlace.hasExpired)
+                  ? "#999"
+                  : "#000",
             }}
             labelStyle={{ fontSize: "0.7em" }}
             onClick={() => {
@@ -827,13 +830,18 @@ class EditStopGeneral extends React.Component {
             {formatMessage({ id: "undo_changes" })}
           </FlatButton>
           <FlatButton
-            disabled={disabled || !stopHasBeenModified}
+            disabled={
+              disabled || (!stopHasBeenModified && !stopPlace.hasExpired)
+            }
             label={formatMessage({ id: "save_new_version" })}
             style={{
               margin: "8 5",
               zIndex: 999,
               fontSize: "0.7em",
-              color: disabled || !stopHasBeenModified ? "#999" : "#000",
+              color:
+                disabled || (!stopHasBeenModified && !stopPlace.hasExpired)
+                  ? "#999"
+                  : "#000",
             }}
             onClick={this.handleSave.bind(this)}
           >


### PR DESCRIPTION
Enable saving expired stops without requiring modifications. This change applies to both regular stops (EditStopGeneral.js) and   multimodal stops (EditParentGeneral.js).

Fixes #1488