### PR TITLE
Take into account Vite's base path when storing redirect path

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -99,10 +99,19 @@ class Header extends React.Component {
   }
 
   handleLogin() {
+    let pathname = window.location.pathname;
+    if (import.meta.env.BASE_URL) {
+      const basename = import.meta.env.BASE_URL;
+      // Extract the base path out, or else it will be applied twice after redirect
+      const pagePath = pathname.split(basename)[1];
+      // if base path ended with '/', it was stripped away in previous step - and needs to be added back unless it's an empty pagePath
+      pathname = `${pagePath && basename.endsWith("/") ? "/" : ""}${pagePath}`;
+    }
+
     if (this.props.auth) {
       sessionStorage.setItem(
         "redirectAfterLogin",
-        window.location.pathname + window.location.search,
+        pathname + window.location.search,
       );
       this.props.auth.login();
     }


### PR DESCRIPTION
Related to: https://github.com/entur/abzu/pull/1521

Vite's base path needs to be extracted from overall pathname, as if it stays there - at the time of the login redirect it will be applied twice.

Tested this with and without base path specified.