### PR TITLE
Fixed issue with opening expired stop places from search box.

### DIFF
--- a/src/graphql/Tiamat/queries.js
+++ b/src/graphql/Tiamat/queries.js
@@ -192,7 +192,7 @@ export const allEntities = gql`
 
 export const getStopById = gql`
   query getStopById($id: String!) {
-    stopPlace(id: $id) {
+    stopPlace(id: $id, allVersions: true) {
       id
       version
       __typename


### PR DESCRIPTION
Added allVersions: true to the query to get all versions, even when the stop place is expired.