### PR TITLE
Fix for expired warnings that are not valid

### DIFF
--- a/src/graphql/Tiamat/queries.js
+++ b/src/graphql/Tiamat/queries.js
@@ -192,7 +192,7 @@ export const allEntities = gql`
 
 export const getStopById = gql`
   query getStopById($id: String!) {
-    stopPlace(id: $id, allVersions: true) {
+    stopPlace(id: $id, versionValidity: MAX_VERSION) {
       id
       version
       __typename


### PR DESCRIPTION
Changed from getting all versions of a stop place to only the latest.