### PR TITLE
Fallback to UNKNOWN if AccessibilityAssessment limitation is null

### DIFF
--- a/src/components/EditStopPage/QuayItem.js
+++ b/src/components/EditStopPage/QuayItem.js
@@ -175,16 +175,18 @@ class QuayItem extends React.Component {
     } = this.props;
     const { formatMessage } = intl;
 
-    const wheelchairAccess = getIn(
-      quay,
-      ["accessibilityAssessment", "limitations", "wheelchairAccess"],
-      AccessibilityLimitationType.UNKNOWN,
-    );
-    const stepFreeAccess = getIn(
-      quay,
-      ["accessibilityAssessment", "limitations", "stepFreeAccess"],
-      AccessibilityLimitationType.UNKNOWN,
-    );
+    const wheelchairAccess =
+      getIn(
+        quay,
+        ["accessibilityAssessment", "limitations", "wheelchairAccess"],
+        AccessibilityLimitationType.UNKNOWN,
+      ) ?? AccessibilityLimitationType.UNKNOWN;
+    const stepFreeAccess =
+      getIn(
+        quay,
+        ["accessibilityAssessment", "limitations", "stepFreeAccess"],
+        AccessibilityLimitationType.UNKNOWN,
+      ) ?? AccessibilityLimitationType.UNKNOWN;
     const isTicketMachinePresent =
       equipmentHelpers.isTicketMachinePresent(quay);
     const isBusShelterPresent =


### PR DESCRIPTION
### Fallback to UNKNOWN if AccessibilityAssessment limitation is null

Fallback `stepFreeAccess` and `wheelChairAccess` in QuayItem.js to UNKNOWN if they are null. 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Other (please describe)

### Issue

If for example Quay has 
```
"accessibilityAssessment": {
      "limitations": {
          "wheelchairAccess": "TRUE",
          "stepFreeAccess": null,
          "escalatorFreeAccess": null,
          "liftFreeAccess": null,
          "audibleSignalsAvailable": null,
          "visualSignsAvailable": null,
          "__typename": "AccessibilityLimitations"
      },
      "__typename": "AccessibilityAssessment"
},
```
The following line in QuayItem.js causes a `TypeError: Cannot read properties of null` because stepFreeAccess is null.

```
const stepFreeHint = formatMessage({
    id: `accessibilityAssessments_stepFreeAccess_${stepFreeAccess.toLowerCase()}`,
});
```

This can happen at least when a Stop Place with Quays is imported via Tiamat import API. 


