### PR TITLE
Add Esri World Imagery as a selectable base layer

### DIFF
--- a/.github/environments/dev.json
+++ b/.github/environments/dev.json
@@ -30,7 +30,8 @@
         "name": "Esri World Imagery",
         "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
         "attribution": "Tiles &copy; Esri &mdash; Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community",
-        "maxZoom": 19
+        "maxZoom": 20,
+        "maxNativeZoom": 18
       },
       {
         "name":"Kartverket topografisk",

--- a/.github/environments/dev.json
+++ b/.github/environments/dev.json
@@ -27,6 +27,12 @@
         "attribution": "&copy; <a href=\"https://osm.org/copyright\">OpenStreetMap</a> contributors"
       },
       {
+        "name": "Esri World Imagery",
+        "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+        "attribution": "Tiles &copy; Esri &mdash; Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community",
+        "maxZoom": 19
+      },
+      {
         "name":"Kartverket topografisk",
         "url": "https://cache.kartverket.no/v1/wmts/1.0.0/topo/default/webmercator/{z}/{y}/{x}.png",
         "attribution": "&copy; <a href=\"http://www.kartverket.no\">Kartverket"


### PR DESCRIPTION
## Summary

Adds Esri World Imagery as a selectable base layer in the map, positioned 
second in the layer list after OpenStreetMap.

The Esri World Imagery tile service is publicly available and requires no 
authentication. It provides high-resolution satellite/aerial imagery useful 
for verifying stop place locations against real-world geography.

## Changes

- `.github/environments/dev.json`: Added Esri World Imagery entry to 
  `baseLayers` with correct tile URL, attribution, and maxZoom

## Disclosure — AI usage

This PR was created using Claude Code, which wrote the change and guided 
the process. Please review with this in mind.