### PR TITLE
Add an option to disable move quays to new stop place button

### DIFF
--- a/src/components/Map/QuayMarker.js
+++ b/src/components/Map/QuayMarker.js
@@ -20,6 +20,7 @@ import ReactDOM from "react-dom/server";
 import { Marker, Popup } from "react-leaflet";
 import { connect } from "react-redux";
 import { StopPlaceActions, UserActions } from "../../actions/";
+import { ConfigContext } from "../../config/ConfigContext";
 import compassIcon from "../../static/icons/compass.png";
 import OSMIcon from "../../static/icons/osm_logo.png";
 import StreetViewIcon from "../../static/icons/street_view_logo.png";
@@ -48,6 +49,7 @@ class QuayMarker extends React.Component {
     draggable: PropTypes.bool.isRequired,
     handleSetCompassBearing: PropTypes.func,
   };
+  static contextType = ConfigContext;
 
   getOSMURL() {
     const { position } = this.props;
@@ -205,6 +207,7 @@ class QuayMarker extends React.Component {
       disabled,
       showPublicCode,
     } = this.props;
+    const { disableMoveQuaysToNewStopPlace } = this.context;
 
     if (!position) return null;
 
@@ -438,6 +441,7 @@ class QuayMarker extends React.Component {
                 />
                 {!disabled &&
                   isEditingStop &&
+                  !disableMoveQuaysToNewStopPlace &&
                   !this.props.currentStopIsMultimodal &&
                   id && (
                     <div style={{ marginTop: 10 }}>

--- a/src/config/ConfigContext.ts
+++ b/src/config/ConfigContext.ts
@@ -26,6 +26,10 @@ export interface Config {
    * By default, Entur's user guide is used there.
    */
   extUserGuideLink?: string;
+  /**
+   * Hides "Move quays to new stop place" button
+   */
+  disableMoveQuaysToNewStopPlace?: boolean;
 }
 
 export interface MapConfig {


### PR DESCRIPTION
A temporary workaround for #1702 - creating a way to hide a "Move quays to ew stop place" button if the value of disableMoveQuaysToNewStopPlace is set true as part of bootstrap.json