### PR TITLE
Introduce withQuayPublicAndPrivateCodes search param on ReportPage

### DIFF
--- a/src/containers/ReportPage.js
+++ b/src/containers/ReportPage.js
@@ -254,6 +254,8 @@ class ReportPage extends React.Component {
       withTags,
       tags,
       versionValidity: showFutureAndExpired ? "MAX_VERSION" : null,
+      // By default, the report page's search word input also uses this:
+      withQuayPublicAndPrivateCodes: true,
       municipalityReference: topoiChips
         .filter((topos) => topos.type === "municipality")
         .map((topos) => topos.id),

--- a/src/graphql/Tiamat/queries.js
+++ b/src/graphql/Tiamat/queries.js
@@ -451,8 +451,8 @@ export const findStop = gql`
 `;
 
 export const findStopForReport = gql`
-    query findStopForReport($query: String, $importedId: String, $municipalityReference: [String], $stopPlaceType: [StopPlaceType], $countyReference: [String], $countryReference: [String], $withoutLocationOnly: Boolean!, $withDuplicateImportedIds: Boolean!, $pointInTime: DateTime, $withNearbySimilarDuplicates: Boolean, $hasParking: Boolean, $tags: [String], $withTags: Boolean, $versionValidity: VersionValidity) {
-        stopPlace(query: $query, importedId: $importedId, municipalityReference: $municipalityReference, stopPlaceType: $stopPlaceType, countyReference: $countyReference, countryReference: $countryReference, withoutLocationOnly: $withoutLocationOnly, withDuplicatedQuayImportedIds: $withDuplicateImportedIds, pointInTime: $pointInTime, size: 300, withNearbySimilarDuplicates: $withNearbySimilarDuplicates, hasParking:$hasParking, tags: $tags, withTags: $withTags, versionValidity: $versionValidity) {
+    query findStopForReport($query: String, $importedId: String, $municipalityReference: [String], $stopPlaceType: [StopPlaceType], $countyReference: [String], $countryReference: [String], $withoutLocationOnly: Boolean!, $withDuplicateImportedIds: Boolean!, $pointInTime: DateTime, $withNearbySimilarDuplicates: Boolean, $hasParking: Boolean, $tags: [String], $withTags: Boolean, $versionValidity: VersionValidity, $withQuayPublicAndPrivateCodes: Boolean) {
+        stopPlace(query: $query, importedId: $importedId, municipalityReference: $municipalityReference, stopPlaceType: $stopPlaceType, countyReference: $countyReference, countryReference: $countryReference, withoutLocationOnly: $withoutLocationOnly, withDuplicatedQuayImportedIds: $withDuplicateImportedIds, pointInTime: $pointInTime, size: 300, withNearbySimilarDuplicates: $withNearbySimilarDuplicates, hasParking:$hasParking, tags: $tags, withTags: $withTags, versionValidity: $versionValidity, withQuayPublicAndPrivateCodes: $withQuayPublicAndPrivateCodes) {
             ...on StopPlace {
                 ...ReportStopPlace
             }


### PR DESCRIPTION
### Summary

The search in report page, along with normal stop place name or id match, will also try to match quays' public or private code

### Issue

The implementation relies on sending withQuayPublicAndPrivateCodes as part of the stop places search request.
