### PR TITLE
Ext Fintraffic - Add privacy policy links

### DIFF
--- a/src/ext/Fintraffic/AdditionalMenuSection/About.tsx
+++ b/src/ext/Fintraffic/AdditionalMenuSection/About.tsx
@@ -10,8 +10,10 @@ const About = () => {
   const defaultLink =
     "https://www.fintraffic.fi/fi/digitaalisetpalvelut/fintrafficin-datapalvelut/liikkumisen-tietopalvelut/peti";
 
-  const swedishPrivacyPolicyLink = "https://www.fintraffic.fi/sites/default/files/2026-04/Dataskyddsbeskrivning_PETI.pdf";
-  const defaultPrivacyPolicyLink = "https://www.fintraffic.fi/sites/default/files/2026-04/Tietosuojaseloste_PETI.pdf";
+  const swedishPrivacyPolicyLink =
+    "https://www.fintraffic.fi/sites/default/files/2026-04/Dataskyddsbeskrivning_PETI.pdf";
+  const defaultPrivacyPolicyLink =
+    "https://www.fintraffic.fi/sites/default/files/2026-04/Tietosuojaseloste_PETI.pdf";
 
   return (
     <MoreMenuItem
@@ -37,7 +39,9 @@ const About = () => {
         localisationId={"Fintraffic-terms"}
       />
       <ExternalLinkMenuItem
-        href={locale == "sv" ? swedishPrivacyPolicyLink : defaultPrivacyPolicyLink}
+        href={
+          locale == "sv" ? swedishPrivacyPolicyLink : defaultPrivacyPolicyLink
+        }
         localisationId={"Fintraffic-privacy"}
       />
       <ExternalLinkMenuItem

--- a/src/ext/Fintraffic/AdditionalMenuSection/About.tsx
+++ b/src/ext/Fintraffic/AdditionalMenuSection/About.tsx
@@ -10,6 +10,9 @@ const About = () => {
   const defaultLink =
     "https://www.fintraffic.fi/fi/digitaalisetpalvelut/fintrafficin-datapalvelut/liikkumisen-tietopalvelut/peti";
 
+  const swedishPrivacyPolicyLink = "https://www.fintraffic.fi/sites/default/files/2026-04/Dataskyddsbeskrivning_PETI.pdf";
+  const defaultPrivacyPolicyLink = "https://www.fintraffic.fi/sites/default/files/2026-04/Tietosuojaseloste_PETI.pdf";
+
   return (
     <MoreMenuItem
       openLeft={true}
@@ -34,7 +37,7 @@ const About = () => {
         localisationId={"Fintraffic-terms"}
       />
       <ExternalLinkMenuItem
-        href={locale == "sv" ? swedishLink : defaultLink}
+        href={locale == "sv" ? swedishPrivacyPolicyLink : defaultPrivacyPolicyLink}
         localisationId={"Fintraffic-privacy"}
       />
       <ExternalLinkMenuItem


### PR DESCRIPTION
### Summary

Add privacy policy links in the _About_ sub menu

### Issue

The current Fintraffic links point to a generic service info page. This change points the links to the correct privacy statement files.

Closes #45

### Unit tests

N/A

### Documentation

N/A
