### PR TITLE
Localize top menu user guide link

### DIFF
--- a/src/components/Header/UserGuide.tsx
+++ b/src/components/Header/UserGuide.tsx
@@ -8,7 +8,9 @@ const UserGuide = () => {
   const defaultUserGuideLink =
     "https://enturas.atlassian.net/wiki/spaces/PUBLIC/pages/1225523302/User+guide+national+stop+place+registry";
   const { formatMessage, locale, defaultLocale } = useIntl();
-  const userGuideLink = extUserGuideLink ? extUserGuideLink[locale || defaultLocale] : defaultUserGuideLink
+  const userGuideLink = extUserGuideLink
+    ? extUserGuideLink[locale || defaultLocale]
+    : defaultUserGuideLink;
 
   return (
     <MenuItem

--- a/src/components/Header/UserGuide.tsx
+++ b/src/components/Header/UserGuide.tsx
@@ -7,12 +7,13 @@ const UserGuide = () => {
   const { extUserGuideLink } = useConfig();
   const defaultUserGuideLink =
     "https://enturas.atlassian.net/wiki/spaces/PUBLIC/pages/1225523302/User+guide+national+stop+place+registry";
-  const { formatMessage } = useIntl();
+  const { formatMessage, locale, defaultLocale } = useIntl();
+  const userGuideLink = extUserGuideLink ? extUserGuideLink[locale || defaultLocale] : defaultUserGuideLink
 
   return (
     <MenuItem
       component={"a"}
-      href={extUserGuideLink || defaultUserGuideLink}
+      href={userGuideLink}
       target="_blank"
       style={{
         fontSize: 12,

--- a/src/config/ConfigContext.ts
+++ b/src/config/ConfigContext.ts
@@ -22,10 +22,10 @@ export interface Config {
    */
   extPath?: string;
   /**
-   * With this it's possible to specify a link that will be shown in User Guide section of the header menu;
+   * With this it's possible to specify localized links that will be shown in User Guide section of the header menu;
    * By default, Entur's user guide is used there.
    */
-  extUserGuideLink?: string;
+  extUserGuideLink?: Record<string, string>;
   /**
    * Hides "Move quays to new stop place" button
    */


### PR DESCRIPTION
### Summary

Localize top menu user guide link. Note that this is a **breaking change** _requiring_ an update to `bootstrap.json` if `extUserGuideLink  `has been previously used.

### Issue

The current top menu user guide link lacks localization. This change points to a localized link if a localized extUserGuideLink has been provided in bootstrap.json

Closes #45

### Unit tests

No unit tests have been added

### Documentation

The line comment for the external user guide link field has been updated
