### PR TITLE
fix: provide AbzuThemeContext in FintrafficThemeProvider

### DIFF
--- a/src/ext/Fintraffic/CustomThemeProvider/FintrafficThemeProvider.tsx
+++ b/src/ext/Fintraffic/CustomThemeProvider/FintrafficThemeProvider.tsx
@@ -2,6 +2,10 @@ import {
   createTheme,
   ThemeProvider as MuiThemeProvider,
 } from "@mui/material/styles";
+import React from "react";
+import { getTiamatEnv } from "../../../config/themeConfig";
+import type { Environment } from "../../../theme";
+import { ThemeContext } from "../../../theme/ThemeProvider";
 import { getTheme } from "./theme";
 
 const muiTheme = createTheme(getTheme());
@@ -11,5 +15,20 @@ export const FintrafficThemeProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  return <MuiThemeProvider theme={muiTheme}>{children}</MuiThemeProvider>;
+  const environment = getTiamatEnv() as Environment;
+
+  const contextValue = {
+    environment,
+    themeConfig: undefined,
+    isConfigLoaded: true,
+    availableThemes: [],
+    currentThemeName: "fintraffic",
+    switchThemeConfig: async () => {},
+  };
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <MuiThemeProvider theme={muiTheme}>{children}</MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
 };

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -34,7 +34,7 @@ interface ThemeContextType {
   switchThemeConfig: (themePath: string) => Promise<void>;
 }
 
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const useTheme = () => {
   const context = useContext(ThemeContext);

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -34,7 +34,9 @@ interface ThemeContextType {
   switchThemeConfig: (themePath: string) => Promise<void>;
 }
 
-export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+export const ThemeContext = createContext<ThemeContextType | undefined>(
+  undefined,
+);
 
 export const useTheme = () => {
   const context = useContext(ThemeContext);


### PR DESCRIPTION
### Summary

\`FintrafficThemeProvider\` only wrapped children with MUI's \`ThemeProvider\`, leaving Abzu's custom \`ThemeContext\` unprovided. \`ModernHeader\`'s \`useEnvironmentStyles\` hook calls \`useTheme()\` from \`src/theme/ThemeProvider.tsx\`, which requires that context — causing a crash when the Fintraffic custom theme feature flag is active.

### Fix

- Export \`ThemeContext\` from \`ThemeProvider.tsx\` so it can be provided outside of \`AbzuThemeProvider\`
- Update \`FintrafficThemeProvider\` to also wrap children in \`ThemeContext.Provider\` with sensible defaults (\`environment\` read from config, empty theme list, no-op \`switchThemeConfig\`)